### PR TITLE
Implement ship movement locking when trading interface is open

### DIFF
--- a/scripts/PlayerShip.gd
+++ b/scripts/PlayerShip.gd
@@ -43,6 +43,9 @@ var acceleration: float = 800.0
 var friction: float = 600.0
 var max_speed: float = 300.0
 
+# Movement lock state for trading interface
+var movement_locked: bool = false
+
 # Player state
 var player_id: String = "550e8400-e29b-41d4-a716-446655440000"
 var current_inventory: Array[Dictionary] = []
@@ -170,6 +173,13 @@ func _physics_process(delta: float) -> void:
 
 func _handle_movement(delta: float) -> void:
 	##Handle player movement input and physics
+	# Check if movement is locked (e.g., when trading interface is open)
+	if movement_locked:
+		# Apply friction to stop the ship but don't process new input
+		velocity = velocity.move_toward(Vector2.ZERO, friction * delta)
+		move_and_slide()
+		return
+
 	var input_vector = Vector2.ZERO
 	var is_moving_left = false
 
@@ -1053,3 +1063,18 @@ func _update_sprite_direction(is_moving_left: bool) -> void:
 		if sprite_2d.texture != sprite_normal:
 			sprite_2d.texture = sprite_normal
 			_log_message("PlayerShip: Switched to normal sprite")
+
+## Movement lock methods for trading interface
+func lock_movement() -> void:
+	##Lock player ship movement (used when trading interface is open)
+	movement_locked = true
+	_log_message("PlayerShip: Movement locked - Ship cannot move while trading interface is open")
+
+func unlock_movement() -> void:
+	##Unlock player ship movement (used when trading interface is closed)
+	movement_locked = false
+	_log_message("PlayerShip: Movement unlocked - Ship movement restored")
+
+func is_movement_locked() -> bool:
+	##Check if movement is currently locked
+	return movement_locked

--- a/scripts/PlayerShip3D.gd
+++ b/scripts/PlayerShip3D.gd
@@ -102,6 +102,9 @@ var speed: float = 200.0
 var acceleration: float = 800.0
 var friction: float = 600.0
 
+## Movement lock state for trading interface
+var movement_locked: bool = false
+
 ## Debug logging control (to prevent spam)
 var debug_log_timer: float = 0.0
 var debug_log_interval: float = 2.0  # Log every 2 seconds instead of every frame
@@ -312,6 +315,13 @@ func _physics_process(delta: float) -> void:
 
 func _handle_input() -> void:
 	##Handle Mario Kart style steering input
+	# Check if movement is locked (e.g., when trading interface is open)
+	if movement_locked:
+		# Reset input values to prevent movement
+		steering_input = 0.0
+		acceleration_input = 0.0
+		return
+
 	# Only log periodically or when significant changes occur, not every frame
 	var should_log_debug = enable_debug_logs and (debug_log_timer >= debug_log_interval or
 		abs(steering_input - last_logged_steering) > 0.5)
@@ -1404,3 +1414,18 @@ func _set_ship_frame_interpolated(frame: float) -> void:
 	##Set ship frame with interpolation support for smooth animation
 	var rounded_frame = int(round(frame))
 	_set_ship_frame(rounded_frame)
+
+## Movement lock methods for trading interface
+func lock_movement() -> void:
+	##Lock player ship movement (used when trading interface is open)
+	movement_locked = true
+	_log_message("PlayerShip3D: Movement locked - Ship cannot move while trading interface is open")
+
+func unlock_movement() -> void:
+	##Unlock player ship movement (used when trading interface is closed)
+	movement_locked = false
+	_log_message("PlayerShip3D: Movement unlocked - Ship movement restored")
+
+func is_movement_locked() -> bool:
+	##Check if movement is currently locked
+	return movement_locked

--- a/scripts/ZoneMain3D.gd
+++ b/scripts/ZoneMain3D.gd
@@ -974,6 +974,11 @@ func open_trading_interface(hub_type: String) -> void:
 		_log_message("ZoneMain3D: ERROR - Trading interface not found!")
 		return
 
+	# Lock player ship movement while trading interface is open
+	if player_ship and player_ship.has_method("lock_movement"):
+		player_ship.lock_movement()
+		_log_message("ZoneMain3D: Player ship movement locked for trading")
+
 	# Clear previous selections
 	selected_debris.clear()
 
@@ -1008,6 +1013,11 @@ func close_trading_interface() -> void:
 
 	if trading_interface:
 		trading_interface.visible = false
+
+	# Unlock player ship movement when trading interface is closed
+	if player_ship and player_ship.has_method("unlock_movement"):
+		player_ship.unlock_movement()
+		_log_message("ZoneMain3D: Player ship movement unlocked")
 
 	_log_message("ZoneMain3D: Trading interface closed")
 

--- a/scripts/ZoneUIManager.gd
+++ b/scripts/ZoneUIManager.gd
@@ -439,7 +439,7 @@ func _on_dump_inventory_pressed() -> void:
 	var dialog = ConfirmationDialog.new()
 	dialog.title = "Confirm Dump Inventory"
 	dialog.dialog_text = confirmation_text
-	dialog.initial_position = Window.WINDOW_INITIAL_POSITION_CENTER_ON_SCREEN
+	dialog.initial_position = Window.WINDOW_INITIAL_POSITION_CENTER_PRIMARY_SCREEN
 
 	# Add to scene temporarily
 	get_tree().current_scene.add_child(dialog)
@@ -507,7 +507,7 @@ func _on_clear_upgrades_pressed() -> void:
 	var dialog = ConfirmationDialog.new()
 	dialog.title = "Confirm Clear All Upgrades"
 	dialog.dialog_text = confirmation_text
-	dialog.initial_position = Window.WINDOW_INITIAL_POSITION_CENTER_ON_SCREEN
+	dialog.initial_position = Window.WINDOW_INITIAL_POSITION_CENTER_PRIMARY_SCREEN
 
 	# Add to scene temporarily
 	get_tree().current_scene.add_child(dialog)
@@ -585,13 +585,6 @@ func _update_trading_result(message: String, color: Color) -> void:
 		trading_result.text = message
 		trading_result.modulate = color
 		print("ZoneUIManager: Trading result updated: %s" % message)
-
-func _update_purchase_result(message: String, color: Color) -> void:
-	##Update purchase result display with message and color
-	if purchase_result:
-		purchase_result.text = message
-		purchase_result.modulate = color
-		print("ZoneUIManager: Purchase result updated: %s" % message)
 
 func _on_trading_close_pressed() -> void:
 	##Handle trading close button press


### PR DESCRIPTION
## 🚀 Ship Movement Locking Feature

This PR implements ship movement locking when the player interacts with trading hubs, providing a better user experience by preventing accidental movement during trading.

### ✨ Features Added:
- **Movement Lock System**: Ship movement is locked when F is pressed at a trading hub
- **Automatic Unlock**: Movement is restored when the trading window is closed
- **Comprehensive Logging**: Debug logs show lock/unlock events for troubleshooting
- **Cross-compatibility**: Works for both 2D and 3D player ship versions

### 🔧 Technical Implementation:
- Added `movement_locked` variable to PlayerShip and PlayerShip3D classes
- Added `lock_movement()`, `unlock_movement()`, and `is_movement_locked()` methods
- Modified input handling to respect movement lock state
- Integrated lock/unlock calls into ZoneMain3D trading interface methods

### 🐛 Bug Fixes:
- Fixed duplicate function declaration in ZoneUIManager.gd
- Updated window constants for Godot 4.4 compatibility

### 🎮 User Experience:
- When player presses F near a trading hub → Ship movement locks
- When trading window is closed → Ship movement unlocks
- WASD input is ignored while locked, preventing accidental drift
- Smooth integration with existing trading system

### ✅ Testing:
- [x] Code compiles without syntax errors
- [x] All pre-commit hooks pass (gitleaks, formatting, etc.)
- [x] Game runs successfully with movement locking working as expected
- [x] Trading hub interaction flow tested and working

**Ready for review and mergepush origin trading-hub-lock* 🎯